### PR TITLE
created tests for 1.1, modified singlereleasemodel

### DIFF
--- a/MusicBrainzMiniAPI/MusicBrainzMiniAPiApp/Services/SingleReleaseModel.cs
+++ b/MusicBrainzMiniAPI/MusicBrainzMiniAPiApp/Services/SingleReleaseModel.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace MusicBrainzMiniAPiApp.Services;
 
@@ -22,6 +23,8 @@ public class SingleReleaseReponse : IResponse
     public string disambiguation { get; set; }
     public string country { get; set; }
     public string statusid { get; set; }
+
+    [JsonProperty("cover-art-archive")]
     public CoverArtArchive coverartarchive { get; set; }
     public string status { get; set; }
     public string quality { get; set; }

--- a/MusicBrainzMiniAPI/MusicBrainzMiniAPiApp/Tests/ValidSpecificReleaseTests.cs
+++ b/MusicBrainzMiniAPI/MusicBrainzMiniAPiApp/Tests/ValidSpecificReleaseTests.cs
@@ -1,0 +1,41 @@
+﻿using MusicBrainzMiniAPiApp.Services;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MusicBrainzMiniAPiApp.Tests;
+public class ValidSpecificReleaseTests
+{
+    MusicBrainzService _singleReleaseService;
+    [OneTimeSetUp]
+    public async Task OneTimeSetupAsync()
+    {
+        _singleReleaseService = new MusicBrainzService();
+        await _singleReleaseService.MakeMusicRequestAsync("1035c7d3-de41-40f9-9c7a-bac0ca7fc361");
+    }
+
+    [Test]
+    public void GivenAValidSpecificRelease_LookupRequest_ReturnsExpectedTitle() 
+    {
+        Assert.That(_singleReleaseService.MusicBrainzDTO.Response.title, Is.EqualTo("Good Times Bad Times / Communication Breakdown"));
+    }
+    [Test]
+    public void GivenAValidSpecificRelease_LookupRequest_ReturnsExpectedDate()
+    {
+        Assert.That(_singleReleaseService.MusicBrainzDTO.Response.date, Is.EqualTo("1969"));
+    }
+    [Test]
+    public void GivenAValidSpecificRelease_LookupRequest_ReturnsExpectedCountry()
+    {
+        Assert.That(_singleReleaseService.MusicBrainzDTO.Response.country, Is.EqualTo("AU"));
+    }
+    [Test]
+    public void GivenAValidSpecificRelease_LookupRequest_ReturnsCoverArt()
+    {
+        Assert.That(_singleReleaseService.MusicBrainzDTO.Response.coverartarchive, Is.Not.Null);
+    }
+}
+


### PR DESCRIPTION
put [JsonProperty("cover-art-archive")] before cover art in the model